### PR TITLE
Include Port Generation Logic in V1 Docker Creator

### DIFF
--- a/src/main/java/io/paradoxical/DockerCreator.java
+++ b/src/main/java/io/paradoxical/DockerCreator.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,8 +40,6 @@ import static com.spotify.docker.client.DockerClient.AttachParameter.STREAM;
 @Deprecated()
 public class DockerCreator {
     private static final Logger logger = LoggerFactory.getLogger(DockerCreator.class);
-
-    private static final Random random = new Random();
 
     public static Container build(DockerClientConfig config) throws InterruptedException, DockerException {
         return new DockerCreator().create(config);

--- a/src/main/java/io/paradoxical/DockerCreator.java
+++ b/src/main/java/io/paradoxical/DockerCreator.java
@@ -87,8 +87,8 @@ public class DockerCreator {
 
         Map<String, List<PortBinding>> portBindings = new HashMap<>();
 
-        for (Integer port : config.getTransientPorts()) {
-            portBindings.put(port.toString(), Collections.singletonList(PortBinding.of("0.0.0.0", random.nextInt(30000) + 15000)));
+        for (Integer transientPort : config.getTransientPorts()) {
+            portBindings.put(transientPort.toString(), Collections.singletonList(PortBinding.of("0.0.0.0", PortGenerator.getNextAvailablePort())));
         }
 
         for (MappedPort mappedPort : config.getMappedPorts()) {

--- a/src/main/java/io/paradoxical/PortGenerator.java
+++ b/src/main/java/io/paradoxical/PortGenerator.java
@@ -1,0 +1,26 @@
+package io.paradoxical;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Random;
+
+public class PortGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(PortGenerator.class);
+    private static final Random random = new Random();
+
+    public static int getNextAvailablePort() {
+        int port = random.nextInt(30000) + 15000;
+        try {
+            ServerSocket serverSocket = new ServerSocket(0);
+            port = serverSocket.getLocalPort();
+            serverSocket.close();
+        } catch (IOException e) {
+            logger.warn("Unable to acquire an available port from the OS, falling back to a random port.");
+        }
+
+        return port;
+    }
+}

--- a/src/main/java/io/paradoxical/v2/DockerCreator.java
+++ b/src/main/java/io/paradoxical/v2/DockerCreator.java
@@ -23,14 +23,11 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class DockerCreator {
     private static final Logger logger = LoggerFactory.getLogger(io.paradoxical.DockerCreator.class);
-
-    private static Random random = new Random();
 
     public static Container build(DockerClientConfig config) throws DockerException, InterruptedException {
         return build(config, null);

--- a/src/main/java/io/paradoxical/v2/DockerCreator.java
+++ b/src/main/java/io/paradoxical/v2/DockerCreator.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
-import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.model.*;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
@@ -16,11 +15,10 @@ import io.paradoxical.DockerClientConfig;
 import io.paradoxical.EnvironmentVar;
 import io.paradoxical.LogMatcher;
 import io.paradoxical.MappedPort;
+import io.paradoxical.PortGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,15 +60,7 @@ public class DockerCreator {
         }
 
         for (Integer transientPort : config.getTransientPorts()) {
-            int port = random.nextInt(30000) + 15000;
-            try {
-                ServerSocket serverSocket = new ServerSocket(0);
-                port = serverSocket.getLocalPort();
-                serverSocket.close();
-            } catch (IOException e) {
-                logger.warn("Unable to acquire an available port from the OS, falling back to a random port.");
-            }
-            ports.bind(ExposedPort.tcp(transientPort), Ports.Binding.bindPort(port));
+            ports.bind(ExposedPort.tcp(transientPort), Ports.Binding.bindPort(PortGenerator.getNextAvailablePort()));
         }
 
         final CreateContainerCmd createContainerCmd =


### PR DESCRIPTION
Makes the port generation logic introduced in https://github.com/paradoxical-io/docker-client/pull/4 available in the V1 Docker Creator